### PR TITLE
add type=button to addProperty buttons

### DIFF
--- a/dist/angularJsonEdit.js
+++ b/dist/angularJsonEdit.js
@@ -230,10 +230,10 @@
           '<option value="true">true</option>' +
           '<option value="">false</option>' +
         '</select>' +
-        '<button class="json-button" ng-click="addProperty()" ng-show="newProperty.type">add property</button>' +
+        '<button class="json-button" type="button" ng-click="addProperty()" ng-show="newProperty.type">add property</button>' +
       '</div>' +
     '<div class="new-property-button-div" ng-show="!showForm">' +
-      '<button class="json-button padded-row" ng-click="showForm = true">+ add property</button>' +
+      '<button class="json-button padded-row" type="button" ng-click="showForm = true">+ add property</button>' +
     '</div>';
 
     var directive = {


### PR DESCRIPTION
The addProperty buttons didn't have a button type set and defaulted to submit. When embedded in a form this resulted in unexpected behavior. Added type="button" to addProperty buttons.
